### PR TITLE
tiny chapter 1 typos

### DIFF
--- a/01-basics-01-bayes-rule.Rmd
+++ b/01-basics-01-bayes-rule.Rmd
@@ -175,7 +175,7 @@ If the false positive rate increases, the probability of a wrong positive result
 
 ### Bayes Updating
 
-In the previous section, we saw that one positive ELISA test yields a probability of having HIV of 12%. To obtain a more convincing probability, one might want to do a second ELISA test after a first one comes up positive. What is the probability of being HIV positive of also the second ELISA test comes back positive?
+In the previous section, we saw that one positive ELISA test yields a probability of having HIV of 12%. To obtain a more convincing probability, one might want to do a second ELISA test after a first one comes up positive. What is the probability of being HIV positive if also the second ELISA test comes back positive?
 
 To solve this problem, we will assume that the correctness of this second test is not influenced by the first ELISA, that is, the tests are independent from each other. This assumption probably does not hold true as it is plausible that if the first test was a false positive, it is more likely that the second one will be one as well. Nonetheless, we stick with the independence assumption for simplicity.
 

--- a/01-basics-02-inf-for-prop.Rmd
+++ b/01-basics-02-inf-for-prop.Rmd
@@ -69,7 +69,8 @@ knitr::kable(
   x = temp,
   booktabs = TRUE,
   caption = 'Prior, likelihood, and posterior probabilities for each of the 9 models',
-  digits = 4
+  digits = 4,
+  format.args = list(scientific = FALSE)
 )
 ```
 


### PR DESCRIPTION
Hi folks,

fantastic book, many thanks for putting it together .. I noticed two tiny typos when reading chapter 1.


1. [Section 1.1.3](https://statswithr.github.io/book/the-basics-of-bayesian-statistics.html#bayes-updating) ```of => if```
2. [Section 1.2.2](https://statswithr.github.io/book/the-basics-of-bayesian-statistics.html#inference-for-a-proportion-bayesian-approach)
the table is outputting  the 0.6 column in scientific notation .